### PR TITLE
Column copying

### DIFF
--- a/afkoppelkansenkaart/processing/height_estimation_algorithm.py
+++ b/afkoppelkansenkaart/processing/height_estimation_algorithm.py
@@ -121,13 +121,6 @@ class HeightEstimatorAlgorithm(OrderedProcessingAlgorithm):
         # for debugging: add the raw layer to the project tree
         # self.add_to_layer_tree_group(zonal_statistics)
 
-        # why not do it in-place (variant without fb) followeed by a DB query?
-        # sql = """
-        # UPDATE kadastraal_perceel_subdivided SET maaiveldhoogte = maaiveldhoogte_median;
-        # ALTER TABLE kadastraal_perceel_subdivided DROP COLUMN maaiveldhoogte_median;
-        # """
-        # execute_sql_query(connection_name, sql, feedback)
-
         input_pol_source_layer.startEditing()
         for feature in zonal_statistics.getFeatures():
 


### PR DESCRIPTION
Hi Leendert, 

Er zat volgens mij een foutje in het kopiëren van de kolom 'maaiveldhoogte_median' uit de temporary laag naar de kolom 'maaiveldhoogte' in de postgis laag. 

Voor zover ik kon zien kwam dat doordat feature.id() niet de waarde uit de kolom 'id' van die feature pakt, maar de index van de feature in de lijst (in de huidige sorting). Daardoor kwam de verkeerde maaiveldhoogte bij het verkeerde perceel.

Door expliciet te refereren naar het attribuut 'id' (feature.attribute('id') ipv feature.id() ) lijkt het wel goed te gaan. 

Misschien een goed idee als je even een blik op de code werpt
